### PR TITLE
Inserted filters and tests

### DIFF
--- a/bloodmoon/filtering.py
+++ b/bloodmoon/filtering.py
@@ -1,0 +1,154 @@
+"""
+Data filters for photons energy range, sources flux and sources positions.
+"""
+
+from collections.abc import Sequence
+
+import numpy.typing as npt
+import numpy as np
+
+
+def data_filter(
+    record: np.recarray,
+    energy_range: int | float | tuple[int | float, int | float] | None,
+    coords: tuple[float, float] | Sequence[tuple[float, float]] | None,
+) -> np.recarray:
+    """
+    Filters the input `record` based on the photons energy and/or position.
+    
+    Args:
+        record: Input simulated data container.
+        energy_range: Energy range in keV for the data filtering. If a specific energy
+                      is given, this will be considered as the maximum filter value.
+                      If a tuple is given, it's interpreted as (`E_min`, `E_max`).
+        coords: Input photons RA/Dec (or sequence of RA/Dec) to filter out.
+    
+    Returns:
+        output: Output filtered data container.
+    """
+    def _energy_mask(
+        mask: npt.NDArray,
+        values: int | float | tuple[int | float, int | float],
+    ) -> npt.NDArray:
+        """Creates an energy mask for the input `record`."""
+        if isinstance(values, (int, float)):
+            mask &= (record["ENERGY"] < values)
+        else:
+            mask &= (record["ENERGY"] > values[0]) & (record["ENERGY"] < values[1])
+        return mask
+
+    def _coords_mask(
+        mask: npt.NDArray,
+        values: tuple[float, float],
+    ) -> npt.NDArray:
+        """Creates a RA/Dec mask for the input `record`."""
+        # to address float64 to float32 conv, we remove
+        # the photons coming from the specified RA/Dec
+        mask &= ~(
+            (np.abs(record["RA"] - values[0]) < 1e-7) &
+            (np.abs(record["DEC"] - values[1]) < 1e-7)
+        )
+        #mask &= (record["RA"] != values[0]) | (record["DEC"] != values[1])
+        return mask
+
+    mask = np.ones(len(record), dtype=bool)
+
+    if energy_range is not None:
+        mask = _energy_mask(mask, energy_range)
+    
+    if coords is not None:
+        if isinstance(coords[0], float):
+            mask = _coords_mask(mask, coords)
+        else:
+            _cmask = np.ones(len(record), dtype=bool)
+            for c in coords:
+                _cmask = _coords_mask(_cmask, c)
+            mask &= _cmask
+    
+    return record[mask]
+
+
+def flux_filter(
+    record: np.recarray,
+    flux_range: int | float | tuple[int | float, int | float],
+) -> np.recarray:
+    """
+    Filters the input catalog `record` for a given flux range.
+
+    Args:
+        record: Input simulated data container.
+        flux_range: Flux range in ph/cm2/s for the data filtering. If a specific flux
+                    is given, this will be considered as the minimum filter value.
+                    If a tuple is given, it's interpreted as (`F_min`, `F_max`).
+
+    Returns:
+        output: Output filtered data container.
+    """
+    mask = np.ones(len(record), dtype=bool)
+    if isinstance(flux_range, (int, float)):
+        mask &= (record["FLUX"] > flux_range)
+    else:
+        mask &= (record["FLUX"] > flux_range[0]) & (record["FLUX"] < flux_range[1])
+    
+    return record[mask]
+
+
+def source_filter(
+    record: np.recarray,
+    n: int | tuple[int, int]
+) -> np.recarray:
+    """
+    Select the `n` brightest sources from the input catalog `record`,
+    or a given interval of sources.
+
+    Args:
+        record: Input simulated data container.
+        n: Filtered interval of sources, up to the n-th brightest
+           source or from `n[0]` to `n[1]` if `n` is a tuple.
+
+    Returns:
+        output: Output filtered data container.
+    
+    Notes:
+        - `n` follows the std Python indexing rules.
+    """
+    sorted_rec = np.sort(record, order="NPHOTONS")[::-1]
+    runs = len(sorted_rec) // len(np.unique(sorted_rec["NAME"]))
+    return sorted_rec[:runs * n] if isinstance(n, int) else sorted_rec[runs * n[0] : runs * n[1]]
+
+
+def catalog_filter(
+    catalog: np.recarray,
+    n: int | tuple[int, int] | None,
+    flux_range: int | float | tuple[int | float, int | float] | None = None,
+) -> np.recarray:
+    """
+    Filters the input `catalog` record based on the sources fluence OR flux.
+    If `n` is given, it selects the `n` brightest sources from the input
+    record, or a given interval of sources. If `flux_range` is given, it
+    filters the input record for a given flux range.
+    
+    Args:
+        catalog: Input simulated data container.
+        n: Filtered interval of sources, up to the n-th brightest
+           source or from `n[0]` to `n[1]` if `n` is a tuple.
+        flux_range: Flux range in ph/cm2/s for the data filtering. If a specific flux
+                    is given, this will be considered as the minimum filter value.
+                    If a tuple is given, it's interpreted as (`F_min`, `F_max`).
+    
+    Returns:
+        output: Output filtered data container.
+    
+    Raises:
+        ValueError: If `n` or `flux_range` are both specified for catalogs filtering.
+    """
+    if n and flux_range:
+        raise ValueError("Specify either 'n' or 'flux_range' to filter the catalog.")
+    
+    if n is not None:
+        return source_filter(catalog, n)
+    elif flux_range is not None:
+        return flux_filter(catalog, flux_range)
+    
+    return catalog
+

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,317 @@
+"""
+Tests for simulated data and catalog filters.
+"""
+
+import unittest
+from unittest import TestCase
+
+import numpy as np
+from bloodmoon.filtering import data_filter
+from bloodmoon.filtering import flux_filter, source_filter, catalog_filter
+
+
+class TestFilters(TestCase):
+    """Tests for the filters in `filtering.py`."""
+    
+    def setUp(self):
+        """Initialize the photons list and the catalog."""
+        # simulated list of photons
+        self.data = np.rec.array([
+            (1,  10.684,  41.269, 22.5),
+            (2,  83.822,  -5.391, 35.2),
+            (3, 201.365, -43.019, 48.7),
+            (4, 150.025,   2.312, 21.9),
+            (5,  53.125, -27.800, 29.5),
+            (6,  13.158, -72.800, 44.1),
+            (7, 299.868,  40.733, 39.3),
+            (8, 187.706,  12.391, 26.8),
+            (9, 123.456, -10.123, 30.4),
+            (10,250.349,  36.467, 47.0),
+        ], dtype=[('ID', 'i4'), ('RA', 'f8'), ('DEC', 'f8'), ('ENERGY', 'f4')])
+        
+        # simulated catalog for single run (e.g., 1ks exposure)
+        self.catalog = np.rec.array([
+            ('SRC_A', 12.4, 120),
+            ('SRC_B', 3.5, 98),
+            ('SRC_C', 87.2, 143),
+            ('SRC_D', 0.95, 65),
+            ('SRC_E', 56.7, 87),
+            ('SRC_F', 23.1, 132),
+            ('SRC_G', 71.8, 77),
+            ('SRC_H', 99.9, 160),
+            ('SRC_I', 14.6, 101),
+            ('SRC_J', 42.3, 110),
+        ], dtype=[('NAME', 'U10'), ('FLUX', 'f8'), ('NPHOTONS', 'i4')])
+
+        # simulated catalog for multiple runs (e.g., 3ks exposure)
+        self.catalog_mult_runs = np.rec.array([
+            ('SRC_A', 12.4, 120), ('SRC_A', 12.4, 120), ('SRC_A', 12.4, 120),
+            ('SRC_B', 3.5, 98), ('SRC_B', 3.5, 98), ('SRC_B', 3.5, 98),
+            ('SRC_C', 87.2, 143), ('SRC_C', 87.2, 143),  ('SRC_C', 87.2, 143),
+            ('SRC_D', 0.95, 65), ('SRC_D', 0.95, 65), ('SRC_D', 0.95, 65),
+            ('SRC_E', 56.7, 87), ('SRC_E', 56.7, 87), ('SRC_E', 56.7, 87),
+            ('SRC_F', 23.1, 132), ('SRC_F', 23.1, 132), ('SRC_F', 23.1, 132),
+            ('SRC_G', 71.8, 77), ('SRC_G', 71.8, 77), ('SRC_G', 71.8, 77),
+            ('SRC_H', 99.9, 160), ('SRC_H', 99.9, 160), ('SRC_H', 99.9, 160),
+            ('SRC_I', 14.6, 101), ('SRC_I', 14.6, 101), ('SRC_I', 14.6, 101),
+            ('SRC_J', 42.3, 110), ('SRC_J', 42.3, 110), ('SRC_J', 42.3, 110),
+        ], dtype=[('NAME', 'U10'), ('FLUX', 'f8'), ('NPHOTONS', 'i4')])
+
+
+    def test_data_energy_filter(self):
+        """Tests for `data_filter()` in the energy channel."""
+        energy_range = 30
+        filtered_data = data_filter(
+            record=self.data,
+            energy_range=energy_range,
+            coords=None,
+        )
+
+        target = np.rec.array([
+            (1,  10.684,  41.269, 22.5),
+            (4, 150.025,   2.312, 21.9),
+            (5,  53.125, -27.800, 29.5),
+            (8, 187.706,  12.391, 26.8),
+        ], dtype=[('ID', 'i4'), ('RA', 'f8'), ('DEC', 'f8'), ('ENERGY', 'f4')])
+
+        np.testing.assert_array_equal(
+            np.sort(filtered_data, order="ENERGY"),
+            np.sort(target, order="ENERGY"),
+        )
+
+        energy_range = (25, 45)
+        filtered_data = data_filter(
+            record=self.data,
+            energy_range=energy_range,
+            coords=None,
+        )
+
+        target = np.rec.array([
+            (2,  83.822,  -5.391, 35.2),
+            (5,  53.125, -27.800, 29.5),
+            (6,  13.158, -72.800, 44.1),
+            (7, 299.868,  40.733, 39.3),
+            (8, 187.706,  12.391, 26.8),
+            (9, 123.456, -10.123, 30.4),
+        ], dtype=[('ID', 'i4'), ('RA', 'f8'), ('DEC', 'f8'), ('ENERGY', 'f4')])
+
+        np.testing.assert_array_equal(
+            np.sort(filtered_data, order="ENERGY"),
+            np.sort(target, order="ENERGY"),
+        )
+
+    def test_data_coords_filter(self):
+        """Tests for `data_filter()` in the RA/Dec channel."""
+        coords = (201.365, -43.019)
+        filtered_data = data_filter(
+            record=self.data,
+            energy_range=None,
+            coords=coords,
+        )
+
+        target = np.rec.array([
+            (1,  10.684,  41.269, 22.5),
+            (2,  83.822,  -5.391, 35.2),
+            (4, 150.025,   2.312, 21.9),
+            (5,  53.125, -27.800, 29.5),
+            (6,  13.158, -72.800, 44.1),
+            (7, 299.868,  40.733, 39.3),
+            (8, 187.706,  12.391, 26.8),
+            (9, 123.456, -10.123, 30.4),
+            (10,250.349,  36.467, 47.0),
+        ], dtype=[('ID', 'i4'), ('RA', 'f8'), ('DEC', 'f8'), ('ENERGY', 'f4')])
+
+        np.testing.assert_array_equal(
+            np.sort(filtered_data, order="ENERGY"),
+            np.sort(target, order="ENERGY"),
+        )
+
+        coords = [
+            (299.868,  40.733),
+            (123.456, -10.123),
+            (83.822,  -5.391),
+        ]
+        filtered_data = data_filter(
+            record=self.data,
+            energy_range=None,
+            coords=coords,
+        )
+
+        target = np.rec.array([
+            (1,  10.684,  41.269, 22.5),
+            (3, 201.365, -43.019, 48.7),
+            (4, 150.025,   2.312, 21.9),
+            (5,  53.125, -27.800, 29.5),
+            (6,  13.158, -72.800, 44.1),
+            (8, 187.706,  12.391, 26.8),
+            (10,250.349,  36.467, 47.0),
+        ], dtype=[('ID', 'i4'), ('RA', 'f8'), ('DEC', 'f8'), ('ENERGY', 'f4')])
+
+        np.testing.assert_array_equal(
+            np.sort(filtered_data, order="ENERGY"),
+            np.sort(target, order="ENERGY"),
+        )
+
+    def test_data_filter(self):
+        """Tests for `data_filter()`."""
+        energy_range = (25, 45)
+        coords = [
+            (299.868,  40.733),
+            (123.456, -10.123),
+            (83.822,  -5.391),
+        ]
+        filtered_data = data_filter(
+            record=self.data,
+            energy_range=energy_range,
+            coords=coords,
+        )
+
+        target = np.rec.array([
+            (5,  53.125, -27.800, 29.5),
+            (6,  13.158, -72.800, 44.1),
+            (8, 187.706,  12.391, 26.8),
+        ], dtype=[('ID', 'i4'), ('RA', 'f8'), ('DEC', 'f8'), ('ENERGY', 'f4')])
+
+        np.testing.assert_array_equal(
+            np.sort(filtered_data, order="ENERGY"),
+            np.sort(target, order="ENERGY"),
+        )
+
+
+    def test_catalog_flux_filter(self):
+        """Tests for `flux_filter()`."""
+        flux_range = 30
+        target = np.rec.array([
+            ('SRC_C', 87.2, 143),
+            ('SRC_E', 56.7, 87),
+            ('SRC_G', 71.8, 77),
+            ('SRC_H', 99.9, 160),
+            ('SRC_J', 42.3, 110),
+        ], dtype=[('NAME', 'U10'), ('FLUX', 'f8'), ('NPHOTONS', 'i4')])
+
+        np.testing.assert_array_equal(
+            np.sort(flux_filter(self.catalog, flux_range), order="FLUX"),
+            np.sort(target, order="FLUX"),
+        )
+
+        flux_range = (20, 90)
+        target = np.rec.array([
+            ('SRC_C', 87.2, 143),
+            ('SRC_E', 56.7, 87),
+            ('SRC_F', 23.1, 132),
+            ('SRC_G', 71.8, 77),
+            ('SRC_J', 42.3, 110),
+        ], dtype=[('NAME', 'U10'), ('FLUX', 'f8'), ('NPHOTONS', 'i4')])
+
+        np.testing.assert_array_equal(
+            np.sort(flux_filter(self.catalog, flux_range), order="FLUX"),
+            np.sort(target, order="FLUX"),
+        )
+
+    def test_catalog_sources_filter(self):
+        """Tests for `source_filter()` on single run."""
+        n = 3
+        target = np.rec.array([
+            ('SRC_C', 87.2, 143),
+            ('SRC_F', 23.1, 132),
+            ('SRC_H', 99.9, 160),
+        ], dtype=[('NAME', 'U10'), ('FLUX', 'f8'), ('NPHOTONS', 'i4')])
+
+        np.testing.assert_array_equal(
+            np.sort(source_filter(self.catalog, n), order="NPHOTONS"),
+            np.sort(target, order="NPHOTONS"),
+        )
+
+        n = (3, 6)
+        target = np.rec.array([
+            ('SRC_A', 12.4, 120),
+            ('SRC_I', 14.6, 101),
+            ('SRC_J', 42.3, 110),
+        ], dtype=[('NAME', 'U10'), ('FLUX', 'f8'), ('NPHOTONS', 'i4')])
+
+        np.testing.assert_array_equal(
+            np.sort(source_filter(self.catalog, n), order="NPHOTONS"),
+            np.sort(target, order="NPHOTONS"),
+        )
+
+    def test_catalog_sources_filter2(self):
+        """Tests for `source_filter()` on multiple runs."""
+        n = 3
+        target = np.rec.array([
+            ('SRC_C', 87.2, 143),
+            ('SRC_C', 87.2, 143),
+            ('SRC_C', 87.2, 143),
+            ('SRC_F', 23.1, 132),
+            ('SRC_F', 23.1, 132),
+            ('SRC_F', 23.1, 132),
+            ('SRC_H', 99.9, 160),
+            ('SRC_H', 99.9, 160),
+            ('SRC_H', 99.9, 160),
+        ], dtype=[('NAME', 'U10'), ('FLUX', 'f8'), ('NPHOTONS', 'i4')])
+
+        np.testing.assert_array_equal(
+            np.sort(source_filter(self.catalog_mult_runs, n), order="NPHOTONS"),
+            np.sort(target, order="NPHOTONS"),
+        )
+
+        n = (3, 6)
+        target = np.rec.array([
+            ('SRC_A', 12.4, 120),
+            ('SRC_A', 12.4, 120),
+            ('SRC_A', 12.4, 120),
+            ('SRC_I', 14.6, 101),
+            ('SRC_I', 14.6, 101),
+            ('SRC_I', 14.6, 101),
+            ('SRC_J', 42.3, 110),
+            ('SRC_J', 42.3, 110),
+            ('SRC_J', 42.3, 110),
+        ], dtype=[('NAME', 'U10'), ('FLUX', 'f8'), ('NPHOTONS', 'i4')])
+
+        np.testing.assert_array_equal(
+            np.sort(source_filter(self.catalog_mult_runs, n), order="NPHOTONS"),
+            np.sort(target, order="NPHOTONS"),
+        )
+
+    def test_catalog_filter(self):
+        """Test for `catalog_filter()`."""
+        n = (3, 6)
+        flux_range = (20, 90)
+
+        # test for ValueError when both `n` and `flux_range` are given
+        with self.assertRaises(ValueError):
+            catalog_filter(self.catalog, n, flux_range)
+        
+        # test for `n`
+        filtered = catalog_filter(self.catalog, n)
+        target = np.rec.array([
+            ('SRC_A', 12.4, 120),
+            ('SRC_I', 14.6, 101),
+            ('SRC_J', 42.3, 110),
+        ], dtype=[('NAME', 'U10'), ('FLUX', 'f8'), ('NPHOTONS', 'i4')])
+
+        np.testing.assert_array_equal(
+            np.sort(filtered, order="NPHOTONS"),
+            np.sort(target, order="NPHOTONS"),
+        )
+
+        # test for `flux_range`
+        filtered = catalog_filter(
+            self.catalog, n=None, flux_range=flux_range,
+        )
+        target = np.rec.array([
+            ('SRC_C', 87.2, 143),
+            ('SRC_E', 56.7, 87),
+            ('SRC_F', 23.1, 132),
+            ('SRC_G', 71.8, 77),
+            ('SRC_J', 42.3, 110),
+        ], dtype=[('NAME', 'U10'), ('FLUX', 'f8'), ('NPHOTONS', 'i4')])
+
+        np.testing.assert_array_equal(
+            np.sort(filtered, order="NPHOTONS"),
+            np.sort(target, order="NPHOTONS"),
+        )
+
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Inserted filters for:
- photons energy
- photons origin coordinates RA/Dec
- sources flux
- number of sources to consider

In the module `filtering.py` the filters are divided in:
- `data_filter()`: which acts on the simulated photons list, and contains the energy and coordinates filters
- `catalog_filter()`: which acts on a catalog, and is a wrapper for the flux and sources filters

I made this division since the photon list can be only filtered by energy and coordinates, while the catalogs by the sources flux.
The 4th filter, i.e. `source_filter()`, is a pseudo-filter which act on the brightest sources in the catalog. With this method is it possible to select only a specified number of sources from the catalog (e.g., the first 20 brightest sources, or the sources between the `n[i]`-th and the `n[j]`-th, still in order of photons emitted).
I wrote `source_filter()` because I think would be more easy to select only a few sources from the catalogs when comparing with the IROS reconstructed sources.

The filters have been tested.