### PR TITLE
New sky variance and significance

### DIFF
--- a/bloodmoon/__init__.py
+++ b/bloodmoon/__init__.py
@@ -50,8 +50,8 @@ from .mask import CodedMaskSpecs
 from .mask import count
 from .mask import cutout
 from .mask import decode
-from .mask import sky_variance
-from .mask import sky_significance
+from .mask import variance
+from .mask import snratio
 from .optim import iros
 from .optim import model_shadowgram
 from .optim import model_sky

--- a/bloodmoon/__init__.py
+++ b/bloodmoon/__init__.py
@@ -19,10 +19,10 @@ count : Function
 decode : Function
     Reconstructs sky images using balanced cross-correlation
 
-sky_variance : Function
+variance : Function
     Computes balanced sky image variance
 
-sky_significance : Function
+snratio : Function
     Computes balanced sky image signal-to-noise ratio
 
 model_shadowgram : Function

--- a/bloodmoon/__init__.py
+++ b/bloodmoon/__init__.py
@@ -19,10 +19,10 @@ count : Function
 decode : Function
     Reconstructs sky images using balanced cross-correlation
 
-variance : Function
+sky_variance : Function
     Computes balanced sky image variance
 
-snratio : Function
+sky_significance : Function
     Computes balanced sky image signal-to-noise ratio
 
 model_shadowgram : Function
@@ -50,8 +50,8 @@ from .mask import CodedMaskSpecs
 from .mask import count
 from .mask import cutout
 from .mask import decode
-from .mask import snratio
-from .mask import variance
+from .mask import sky_variance
+from .mask import sky_significance
 from .optim import iros
 from .optim import model_shadowgram
 from .optim import model_sky

--- a/bloodmoon/mask.py
+++ b/bloodmoon/mask.py
@@ -365,24 +365,23 @@ def solid_angle(
     height: float,
     distance: float,
 ) -> npt.NDArray:
-    r"""
-    Computes the solid angle subtended by a rectangular mask at a given
-    distance, given its physical width and height, as observed from a
-    detector element located at coordinates (x, y).            
+    """
+    Computes the solid angle subtended by a rectangular mask at a given distance from the detector, 
+    as seen from a point (x, y) of the detector plane. 
 
     Args:
         x (float | NDArray):
-            Observer coord along the x-axis wrt plate bottom-left corner.
+            Detector element position over the x-axis wrt mask bottom-left corner.
             A non-zero solid angle requires that `0 <= x <= width / 2`.
         y (float | NDArray):
-            Observer coord along the y-axis wrt plate bottom-left corner.
+            Detector element position over the y-axis wrt mask bottom-left corner.
             A non-zero solid angle requires that `0 <= y <= height / 2`.
         width (float):
-            Width of the rectangular plate.
+            Mask width.
         height (float):
-            Height of the rectangular plate.
+            Mask height.
         distance (float):
-            Distance between the plate and the observer.
+            Distance between the plate and the detector.
 
     Returns:
         output (float | NDArray):
@@ -392,7 +391,7 @@ def solid_angle(
         ValueError: If input coords (x, y) not in the range [0, width / 2] x [0, height / 2].
 
     ## Notes
-        - CFR with:
+        - See also:
             * https://github.com/yuri-evangelista/CodedMasks/blob/26a5bb2fa08e37c645f85d55a3a1ef038fe7497d/mask_utils/imaging_utils.py#L58
             * https://vixra.org/pdf/2001.0603v2.pdf [Eq. 27, 34]
     """
@@ -439,16 +438,9 @@ def solid_angle(
 
 def solid_angle_profile(camera: CodedMaskCamera) -> npt.NDArray:
     """
-    Computes the sky solid angle profile seen by each active element
-    of the coded-mask camera detector.
-
-    The solid angle is computed by considering only the instrument
-    geometry, taking into account the mask physical dimension, which
-    represents the base of a pyramid whose vertex sits on the center
-    of each active element of the detector plane, and all the active
-    elements coordinates (along the plane).
-    The final array is masked with the detector bulk profile.
-
+    Computes the solid angle subtended by a rectangular mask at a given distance from the detector, 
+    relative to the center of each active element of the detector. 
+    
     Args:
         camera (CodedMaskCamera):
             Camera instance containing the system geometry info.
@@ -458,8 +450,7 @@ def solid_angle_profile(camera: CodedMaskCamera) -> npt.NDArray:
             2D array representing the solid angle profile.
     
     ## Notes:
-        - CFR with:
-            * https://github.com/yuri-evangelista/CodedMasks/blob/26a5bb2fa08e37c645f85d55a3a1ef038fe7497d/mask_utils/imaging_utils.py#L104
+        - See also `solid_angle`
     """
     # define mask physical dim (width, height)
     d = camera.specs.mask_detector_distance
@@ -486,8 +477,7 @@ def variance(
     detector: npt.NDArray,
 ) -> npt.NDArray:
     """
-    Reconstructs balanced sky variance from detector image by using
-    the expected photon counts, to neglect Poisson fluctuations.
+    Reconstructs balanced sky variance from detector image.
 
     Args:
         camera (CodedMaskCamera):
@@ -498,11 +488,10 @@ def variance(
     Returns:
         output (NDArray):
             Balanced variance map of the reconstructed sky image.
-            To conserve the observed total counts, the output array
-            is clipped in the range `[1e-8, detector.sum()]`.
+            To conserve the observed total counts, the output array is clipped in the range `[1e-8, detector.sum()]`.
     
     ## Notes:
-        - CFR with:
+        - See also:
             * https://github.com/yuri-evangelista/CodedMasks/blob/26a5bb2fa08e37c645f85d55a3a1ef038fe7497d/mask_utils/imaging_utils.py#L134
     """
     # retrieve total detector counts and total active elements
@@ -520,9 +509,7 @@ def variance(
     bal = np.square(camera.balancing) * sum_det / np.square(sum_bulk)
     covar = correlate(camera.decoder, lambda_, mode="full")
 
-    var_bal = (
-        var + bal - 2 * covar * camera.balancing / sum_bulk
-    )
+    var_bal = var + bal - 2 * covar * camera.balancing / sum_bulk
     return np.clip(var_bal, a_min=1e-8, a_max=detector.sum())
 
 

--- a/bloodmoon/mask.py
+++ b/bloodmoon/mask.py
@@ -488,7 +488,6 @@ def variance(
     Returns:
         output (NDArray):
             Balanced variance map of the reconstructed sky image.
-            To conserve the observed total counts, the output array is clipped in the range `[1e-8, detector.sum()]`.
     
     ## Notes:
         - See also:
@@ -509,8 +508,7 @@ def variance(
     bal = np.square(camera.balancing) * sum_det / np.square(sum_bulk)
     covar = correlate(camera.decoder, lambda_, mode="full")
 
-    var_bal = var + bal - 2 * covar * camera.balancing / sum_bulk
-    return np.clip(var_bal, a_min=1e-8, a_max=detector.sum())
+    return var + bal - 2 * covar * camera.balancing / sum_bulk
 
 
 def snratio(
@@ -518,19 +516,22 @@ def snratio(
     var: npt.NDArray,
 ) -> npt.NDArray:
     """
-    Computes signal-to-noise ratio from sky signal and variance arrays.
+    Calculate signal-to-noise ratio from sky signal and variance arrays.
 
     Args:
-        sky (NDArray):
-            Sky signal values.
-        var (NDArray):
-            Sky variance values.
+        sky: Array containing sky signal values.
+        var: Array containing variance values. Negative values are clipped to 0.
 
     Returns:
-        output (NDArray):
-            Sky significance calculated as `sky / sqrt(var)`.
+        NDArray: Signal-to-noise ratio calculated as sky/sqrt(variance).
+
+    Notes:
+        - Variance's boundary frames with elements close to zero are replaced with infinity.
+        - Variance's minimum is clipped at 0 if any negative value are present in the array.
     """
-    return sky / np.sqrt(var)
+    variance_clipped = np.clip(var, a_min=0.0, a_max=None) if np.any(var < 0) else var
+    variance_unframed = _unframe(variance_clipped, value=np.inf)
+    return sky / np.sqrt(variance_unframed)
 
 
 def psf(camera: CodedMaskCamera) -> npt.NDArray:

--- a/bloodmoon/mask.py
+++ b/bloodmoon/mask.py
@@ -495,7 +495,7 @@ def detector_solid_angle(camera: CodedMaskCamera) -> npt.NDArray:
     return solid_angle(xs, ys, *maskplate_physdim, d) * (camera.bulk > 0)
 
 
-def sky_variance(
+def variance(
     camera: CodedMaskCamera,
     detector: npt.NDArray,
 ) -> npt.NDArray:
@@ -540,7 +540,7 @@ def sky_variance(
     return np.clip(var_bal, a_min=1e-8, a_max=detector.sum())
 
 
-def sky_significance(
+def snratio(
     sky: npt.NDArray,
     var: npt.NDArray,
 ) -> npt.NDArray:
@@ -555,7 +555,7 @@ def sky_significance(
 
     Returns:
         output (NDArray):
-            Sky significance calculated as `sky / sqrt(variance)`.
+            Sky significance calculated as `sky / sqrt(var)`.
     """
     return sky / np.sqrt(var)
 

--- a/bloodmoon/mask.py
+++ b/bloodmoon/mask.py
@@ -445,10 +445,10 @@ def solid_angle(
         ((width - x), (height - y)),
         (x, (height - y)),
     )
-    Omega = tuple(
+    omega = tuple(
         on_axis_solid_angle(2 * a, 2 * b) for a, b in sub_portions
     )
-    return sum(Omega) / len(Omega)
+    return sum(omega) / len(omega)
 
 
 def detector_solid_angle(camera: CodedMaskCamera) -> npt.NDArray:
@@ -475,8 +475,6 @@ def detector_solid_angle(camera: CodedMaskCamera) -> npt.NDArray:
         - CFR with:
             * https://github.com/yuri-evangelista/CodedMasks/blob/26a5bb2fa08e37c645f85d55a3a1ef038fe7497d/mask_utils/imaging_utils.py#L104
     """
-    UPX, UPY = camera.upscale_f
-
     # define mask physical dim (width, height)
     d = camera.specs.mask_detector_distance
     maxx, minx = camera.specs.mask_maxx, camera.specs.mask_minx
@@ -489,12 +487,12 @@ def detector_solid_angle(camera: CodedMaskCamera) -> npt.NDArray:
     #   - the solid angle is masked with the bulk active elements
     _binsx, _binsy = camera.bins_detector
     centers_x, centers_y = (
-        _binsx[:-1] + camera.specs.mask_deltax / (2 * UPX),
-        _binsy[:-1] + camera.specs.mask_deltay / (2 * UPY),
+        _binsx[:-1] + camera.specs.mask_deltax / (2 * camera.upscale_f.x),
+        _binsy[:-1] + camera.specs.mask_deltay / (2 * camera.upscale_f.y),
     )
-    x = np.clip(maxx - np.abs(centers_x[np.newaxis, :]), a_min=0, a_max=None)
-    y = np.clip(maxy - np.abs(centers_y[:, np.newaxis]), a_min=0, a_max=None)
-    return solid_angle(x, y, *maskplate_physdim, d) * (camera.bulk > 0)
+    xs = np.clip(maxx - np.abs(centers_x[np.newaxis, :]), a_min=0, a_max=None)
+    ys = np.clip(maxy - np.abs(centers_y[:, np.newaxis]), a_min=0, a_max=None)
+    return solid_angle(xs, ys, *maskplate_physdim, d) * (camera.bulk > 0)
 
 
 def sky_variance(
@@ -525,16 +523,16 @@ def sky_variance(
     sum_det, sum_bulk = map(np.sum, (detector, camera.bulk))
 
     # compute expected counts for the detector image
-    # - the expected counts array `Lambda` can be built as the product between
-    #   a normalised matrix `Omega` representing the solid angle seen by each
+    # - the expected counts array `lambda` can be built as the product between
+    #   a normalised matrix `omega` representing the solid angle seen by each
     #   active pixel; and the total observed detector counts (i.e., `sum_det`)
-    Omega = detector_solid_angle(camera)
-    Lambda = sum_det * Omega / Omega.sum()
+    omega = detector_solid_angle(camera)
+    lambda_ = sum_det * omega / omega.sum()
 
     # balanced variance components
-    var = correlate(np.square(camera.decoder), Lambda, mode="full")
+    var = correlate(np.square(camera.decoder), lambda_, mode="full")
     bal = np.square(camera.balancing) * sum_det / np.square(sum_bulk)
-    covar = correlate(camera.decoder, Lambda, mode="full")
+    covar = correlate(camera.decoder, lambda_, mode="full")
 
     var_bal = (
         var + bal - 2 * covar * camera.balancing / sum_bulk

--- a/bloodmoon/mask.py
+++ b/bloodmoon/mask.py
@@ -366,9 +366,9 @@ def solid_angle(
     distance: float,
 ) -> npt.NDArray:
     """
-    Computes the solid angle covered by a rectangular plate of physical
-    dimension `width` X `height` at a given `distance` from an observer
-    located at `(x, y)` wrt the plate bottom-left corner.
+    Computes the solid angle subtended by a rectangular mask, given its
+    physical width and height, as observed from a detector element
+    located at coordinates (x, y).
 
                         |-------- width --------|
                                 |
@@ -451,7 +451,7 @@ def solid_angle(
     return sum(omega) / len(omega)
 
 
-def detector_solid_angle(camera: CodedMaskCamera) -> npt.NDArray:
+def solid_angle_profile(camera: CodedMaskCamera) -> npt.NDArray:
     """
     Computes the sky solid angle profile seen by each active element
     of the coded-mask camera detector.
@@ -526,7 +526,7 @@ def variance(
     # - the expected counts array `lambda` can be built as the product between
     #   a normalised matrix `omega` representing the solid angle seen by each
     #   active pixel; and the total observed detector counts (i.e., `sum_det`)
-    omega = detector_solid_angle(camera)
+    omega = solid_angle_profile(camera)
     lambda_ = sum_det * omega / omega.sum()
 
     # balanced variance components

--- a/bloodmoon/mask.py
+++ b/bloodmoon/mask.py
@@ -358,48 +358,208 @@ def decode(
     return cc_bal
 
 
-def variance(
+def solid_angle(
+    x: float | npt.NDArray,
+    y: float | npt.NDArray,
+    width: float,
+    height: float,
+    distance: float,
+) -> npt.NDArray:
+    """
+    Computes the solid angle covered by a rectangular plate of physical
+    dimension `width` X `height` at a given `distance` from an observer
+    located at `(x, y)` wrt the plate bottom-left corner.
+
+                        |-------- width --------|
+                                |
+                         _______|_______________       _ _
+                        |       |               |       |
+                        |   4   |       3       |       |
+                        |       |               |       |
+                     ___|_______|_______________|____   |height
+                        |       |               |       |
+                        |   1  y|       2       |       |    
+                        |_______|_______________|      _|_
+                            x   |
+                                |                 
+    
+    To compute the solid angle, the plate is divided in four sub-portions,
+    with the observer located on one corner of each one. The plate solid
+    angle can be computed by averaging the sub-portions solid angles seen
+    by an on-axis observer.
+
+    The sub-rectangules have areas:
+        * `A_r1 = x * y`
+        * `A_r2 = (width - x) * y`
+        * `A_r3 = (width - x) * (height - y)`
+        * `A_r4 = x * (height - y)`
+
+    Args:
+        x (float | NDArray):
+            Observer coord along the x-axis wrt plate bottom-left corner.
+            A non-zero solid angle requires that `0 <= x <= width / 2`.
+        y (float | NDArray):
+            Observer coord along the y-axis wrt plate bottom-left corner.
+            A non-zero solid angle requires that `0 <= y <= height / 2`.
+        width (float):
+            Width of the rectangular plate.
+        height (float):
+            Height of the rectangular plate.
+        distance (float):
+            Distance between the plate and the observer.
+
+    Returns:
+        output (float | NDArray):
+            Solid angle on the plate seen by the observer.
+    
+    Raises:
+        ValueError: If input coords (x, y) not in the range [0, width / 2] x [0, height / 2].
+
+    ## Notes
+        - CFR with:
+            * https://github.com/yuri-evangelista/CodedMasks/blob/26a5bb2fa08e37c645f85d55a3a1ef038fe7497d/mask_utils/imaging_utils.py#L58
+            * https://vixra.org/pdf/2001.0603v2.pdf [Eq. 27, 34]
+    """
+    def on_axis_solid_angle(
+        a: float | npt.NDArray,
+        b: float | npt.NDArray,
+    ) -> float | npt.NDArray:
+        """
+        Computes the solid angle covered by a plate of dimension
+        `a` X `b` wrt an observer at a given ox-axis `distance`.
+        """
+        alpha = a / (2 * distance)
+        beta = b / (2 * distance)
+        return 4 * np.arctan((alpha * beta) / np.sqrt(1 + alpha**2 + beta**2))
+    
+    if (
+        np.any((x < 0) | (x > width / 2) | (y < 0) | (y > height / 2))
+    ):
+        raise ValueError(
+            f"Invalid coords (x, y). Coords must be in the range [0, {width / 2}] x [0, {height / 2}]."
+        )
+    
+    sub_portions = (
+        (x, y),
+        ((width - x), y),
+        ((width - x), (height - y)),
+        (x, (height - y)),
+    )
+    Omega = tuple(
+        on_axis_solid_angle(2 * a, 2 * b) for a, b in sub_portions
+    )
+    return sum(Omega) / len(Omega)
+
+
+def detector_solid_angle(camera: CodedMaskCamera) -> npt.NDArray:
+    """
+    Computes the sky solid angle profile seen by each active element
+    of the coded-mask camera detector.
+
+    The solid angle is computed by considering only the instrument
+    geometry, taking into account the mask physical dimension, which
+    represents the base of a pyramid whose vertex sits on the center
+    of each active element of the detector plane, and all the active
+    elements coordinates (along the plane).
+    The final array is masked with the detector bulk profile.
+
+    Args:
+        camera (CodedMaskCamera):
+            Camera instance containing the system geometry info.
+    
+    Returns:
+        output (NDArray):
+            2D array representing the solid angle profile.
+    
+    ## Notes:
+        - CFR with:
+            * https://github.com/yuri-evangelista/CodedMasks/blob/26a5bb2fa08e37c645f85d55a3a1ef038fe7497d/mask_utils/imaging_utils.py#L104
+    """
+    UPX, UPY = camera.upscale_f
+
+    # define mask physical dim (width, height)
+    d = camera.specs.mask_detector_distance
+    maxx, minx = camera.specs.mask_maxx, camera.specs.mask_minx
+    maxy, miny = camera.specs.mask_maxy, camera.specs.mask_miny
+    maskplate_physdim = (maxx - minx, maxy - miny)
+
+    # compute x- and y-coords for the detector elements solid angle
+    #   - first define detector plane active elements positions
+    #   - elements coords are clipped to remove binning artefact
+    #   - the solid angle is masked with the bulk active elements
+    _binsx, _binsy = camera.bins_detector
+    centers_x, centers_y = (
+        _binsx[:-1] + camera.specs.mask_deltax / (2 * UPX),
+        _binsy[:-1] + camera.specs.mask_deltay / (2 * UPY),
+    )
+    x = np.clip(maxx - np.abs(centers_x[np.newaxis, :]), a_min=0, a_max=None)
+    y = np.clip(maxy - np.abs(centers_y[:, np.newaxis]), a_min=0, a_max=None)
+    return solid_angle(x, y, *maskplate_physdim, d) * (camera.bulk > 0)
+
+
+def sky_variance(
     camera: CodedMaskCamera,
     detector: npt.NDArray,
 ) -> npt.NDArray:
     """
-    Reconstruct balanced sky variance from detector counts.
+    Reconstructs balanced sky variance from detector image by using
+    the expected photon counts, to neglect Poisson fluctuations.
 
     Args:
-        camera: CodedMaskCamera object containing mask and decoder patterns
-        detector: 2D array of detector counts
+        camera (CodedMaskCamera):
+            Camera instance containing mask and decoder patterns.
+        detector (NDArray):
+            2D array of detector counts.
 
     Returns:
-        Variance map of the reconstructed sky image
+        output (NDArray):
+            Balanced variance map of the reconstructed sky image.
+            To conserve the observed total counts, the output array
+            is clipped in the range `[1e-8, detector.sum()]`.
+    
+    ## Notes:
+        - CFR with:
+            * https://github.com/yuri-evangelista/CodedMasks/blob/26a5bb2fa08e37c645f85d55a3a1ef038fe7497d/mask_utils/imaging_utils.py#L134
     """
-    cc = correlate(camera.decoder, detector, mode="full")
-    var = correlate(np.square(camera.decoder), detector, mode="full")
+    # retrieve total detector counts and total active elements
     sum_det, sum_bulk = map(np.sum, (detector, camera.bulk))
-    var_bal = var + np.square(camera.balancing) * sum_det / np.square(sum_bulk) - 2 * cc * camera.balancing / sum_bulk
-    return var_bal
+
+    # compute expected counts for the detector image
+    # - the expected counts array `Lambda` can be built as the product between
+    #   a normalised matrix `Omega` representing the solid angle seen by each
+    #   active pixel; and the total observed detector counts (i.e., `sum_det`)
+    Omega = detector_solid_angle(camera)
+    Lambda = sum_det * Omega / Omega.sum()
+
+    # balanced variance components
+    var = correlate(np.square(camera.decoder), Lambda, mode="full")
+    bal = np.square(camera.balancing) * sum_det / np.square(sum_bulk)
+    covar = correlate(camera.decoder, Lambda, mode="full")
+
+    var_bal = (
+        var + bal - 2 * covar * camera.balancing / sum_bulk
+    )
+    return np.clip(var_bal, a_min=1e-8, a_max=detector.sum())
 
 
-def snratio(
+def sky_significance(
     sky: npt.NDArray,
     var: npt.NDArray,
 ) -> npt.NDArray:
     """
-    Calculate signal-to-noise ratio from sky signal and variance arrays.
+    Computes signal-to-noise ratio from sky signal and variance arrays.
 
     Args:
-        sky: Array containing sky signal values.
-        var: Array containing variance values. Negative values are clipped to 0.
+        sky (NDArray):
+            Sky signal values.
+        var (NDArray):
+            Sky variance values.
 
     Returns:
-        NDArray: Signal-to-noise ratio calculated as sky/sqrt(variance).
-
-    Notes:
-        - Variance's boundary frames with elements close to zero are replaced with infinity.
-        - Variance's minimum is clipped at 0 if any negative value are present in the array.
+        output (NDArray):
+            Sky significance calculated as `sky / sqrt(variance)`.
     """
-    variance_clipped = np.clip(var, a_min=0.0, a_max=None) if np.any(var < 0) else var
-    variance_unframed = _unframe(variance_clipped, value=np.inf)
-    return sky / np.sqrt(variance_unframed)
+    return sky / np.sqrt(var)
 
 
 def psf(camera: CodedMaskCamera) -> npt.NDArray:

--- a/bloodmoon/mask.py
+++ b/bloodmoon/mask.py
@@ -365,34 +365,10 @@ def solid_angle(
     height: float,
     distance: float,
 ) -> npt.NDArray:
-    """
-    Computes the solid angle subtended by a rectangular mask, given its
-    physical width and height, as observed from a detector element
-    located at coordinates (x, y).
-
-                        |-------- width --------|
-                                |
-                         _______|_______________       _ _
-                        |       |               |       |
-                        |   4   |       3       |       |
-                        |       |               |       |
-                     ___|_______|_______________|____   |height
-                        |       |               |       |
-                        |   1  y|       2       |       |    
-                        |_______|_______________|      _|_
-                            x   |
-                                |                 
-    
-    To compute the solid angle, the plate is divided in four sub-portions,
-    with the observer located on one corner of each one. The plate solid
-    angle can be computed by averaging the sub-portions solid angles seen
-    by an on-axis observer.
-
-    The sub-rectangules have areas:
-        * `A_r1 = x * y`
-        * `A_r2 = (width - x) * y`
-        * `A_r3 = (width - x) * (height - y)`
-        * `A_r4 = x * (height - y)`
+    r"""
+    Computes the solid angle subtended by a rectangular mask at a given
+    distance, given its physical width and height, as observed from a
+    detector element located at coordinates (x, y).            
 
     Args:
         x (float | NDArray):
@@ -439,6 +415,16 @@ def solid_angle(
             f"Invalid coords (x, y). Coords must be in the range [0, {width / 2}] x [0, {height / 2}]."
         )
     
+    # To compute the solid angle, the plate is divided in four sub-portions,
+    # with the observer located on one corner of each one. The plate solid
+    # angle can be computed by averaging the sub-portions solid angles seen
+    # by an on-axis observer.
+    #
+    # The sub-rectangules have areas:
+    #    * `A_r1 = x * y`
+    #    * `A_r2 = (width - x) * y`
+    #    * `A_r3 = (width - x) * (height - y)`
+    #    * `A_r4 = x * (height - y)`
     sub_portions = (
         (x, y),
         ((width - x), y),

--- a/bloodmoon/optim.py
+++ b/bloodmoon/optim.py
@@ -29,8 +29,8 @@ from .mask import count
 from .mask import cutout
 from .mask import decode
 from .mask import interpmax
-from .mask import sky_variance
-from .mask import sky_significance
+from .mask import variance
+from .mask import snratio
 
 
 def _modsech(
@@ -854,12 +854,12 @@ def iros(
         # which may result in very few counts.
         # TODO: improve on this only sorting matrix elements over a threshold.
         snrs = tuple(
-            sky_significance(sky, np.clip(var_, a_min=1, a_max=None)) for sky, var_ in zip(skymaps, varmaps)
+            snratio(sky, np.clip(var_, a_min=1, a_max=None)) for sky, var_ in zip(skymaps, varmaps)
         )
         return snrs
 
     detectors = tuple(count(camera, sdl.data)[0] for sdl in sdls)
-    variances = tuple(sky_variance(camera, d) for d in detectors)
+    variances = tuple(variance(camera, d) for d in detectors)
     skies = tuple(decode(camera, d) for d in detectors)
     for i in range(max_iterations):
         snrs = compute_snratios(skies, variances)

--- a/bloodmoon/optim.py
+++ b/bloodmoon/optim.py
@@ -29,8 +29,8 @@ from .mask import count
 from .mask import cutout
 from .mask import decode
 from .mask import interpmax
-from .mask import snratio
-from .mask import variance
+from .mask import sky_variance
+from .mask import sky_significance
 
 
 def _modsech(
@@ -853,11 +853,13 @@ def iros(
         # variance is clipped to improve numerical stability for off-axis sources,
         # which may result in very few counts.
         # TODO: improve on this only sorting matrix elements over a threshold.
-        snrs = tuple(snratio(sky, np.clip(var_, a_min=1, a_max=None)) for sky, var_ in zip(skymaps, varmaps))
+        snrs = tuple(
+            sky_significance(sky, np.clip(var_, a_min=1, a_max=None)) for sky, var_ in zip(skymaps, varmaps)
+        )
         return snrs
 
     detectors = tuple(count(camera, sdl.data)[0] for sdl in sdls)
-    variances = tuple(variance(camera, d) for d in detectors)
+    variances = tuple(sky_variance(camera, d) for d in detectors)
     skies = tuple(decode(camera, d) for d in detectors)
     for i in range(max_iterations):
         snrs = compute_snratios(skies, variances)

--- a/demo/demo.ipynb
+++ b/demo/demo.ipynb
@@ -447,18 +447,18 @@
    "id": "8e8acc65-6ca2-4d6a-b940-af031bef1811",
    "metadata": {},
    "source": [
-    "The `variance` function computes statistical variance for camera and detector images:\n"
+    "The `sky_variance` function computes statistical variance for camera and detector images:\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "6ee6fbf1-fcf6-4775-9c7d-67f3ebba2c87",
    "metadata": {},
    "outputs": [],
    "source": [
     "from bloodmoon import codedmask, simulation, count, decode\n",
-    "from bloodmoon import variance\n",
+    "from bloodmoon import sky_variance\n",
     "\n",
     "wfm = codedmask(\"wfm_mask.fits\")\n",
     "sdl = simulation(\"simdir/cam1a/cam1a_reconstructed.fits\")\n",
@@ -466,7 +466,7 @@
     "detector, _ = count(wfm, sdl.data)\n",
     "balanced = decode(wfm, detector)\n",
     "\n",
-    "var_ = variance(wfm, detector)"
+    "var_ = sky_variance(wfm, detector)"
    ]
   },
   {
@@ -498,18 +498,18 @@
    "id": "33330d10-6190-4df9-9cf6-c317871461d7",
    "metadata": {},
    "source": [
-    "The `snratio` function calculates signal-to-noise ratio significance, handling edge cases such as sparse count distributions from off-axis sources."
+    "The `sky_significance` function calculates signal-to-noise ratio significance, handling edge cases such as sparse count distributions from off-axis sources."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "2d3e83e1-1899-4f23-9e67-9cbb9a86c17b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bloodmoon import codedmask, simulation, count, decode, variance\n",
-    "from bloodmoon import snratio\n",
+    "from bloodmoon import codedmask, simulation, count, decode, sky_variance\n",
+    "from bloodmoon import sky_significance\n",
     "\n",
     "wfm = codedmask(\"wfm_mask.fits\")\n",
     "sdl = simulation(\"simdir/cam1a/cam1a_reconstructed.fits\")\n",
@@ -517,7 +517,7 @@
     "detector, _ = count(wfm, sdl.data)\n",
     "balanced = decode(wfm, detector)\n",
     "\n",
-    "snr = snratio(balanced, variance(wfm, detector))"
+    "snr = sky_significance(balanced, sky_variance(wfm, detector))"
    ]
   },
   {

--- a/demo/demo.ipynb
+++ b/demo/demo.ipynb
@@ -447,7 +447,7 @@
    "id": "8e8acc65-6ca2-4d6a-b940-af031bef1811",
    "metadata": {},
    "source": [
-    "The `sky_variance` function computes statistical variance for camera and detector images:\n"
+    "The `variance` function computes statistical variance for camera and detector images:\n"
    ]
   },
   {
@@ -458,7 +458,7 @@
    "outputs": [],
    "source": [
     "from bloodmoon import codedmask, simulation, count, decode\n",
-    "from bloodmoon import sky_variance\n",
+    "from bloodmoon import variance\n",
     "\n",
     "wfm = codedmask(\"wfm_mask.fits\")\n",
     "sdl = simulation(\"simdir/cam1a/cam1a_reconstructed.fits\")\n",
@@ -466,7 +466,7 @@
     "detector, _ = count(wfm, sdl.data)\n",
     "balanced = decode(wfm, detector)\n",
     "\n",
-    "var_ = sky_variance(wfm, detector)"
+    "var_ = variance(wfm, detector)"
    ]
   },
   {
@@ -498,7 +498,7 @@
    "id": "33330d10-6190-4df9-9cf6-c317871461d7",
    "metadata": {},
    "source": [
-    "The `sky_significance` function calculates signal-to-noise ratio significance, handling edge cases such as sparse count distributions from off-axis sources."
+    "The `snratio` function calculates signal-to-noise ratio significance, handling edge cases such as sparse count distributions from off-axis sources."
    ]
   },
   {
@@ -508,8 +508,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bloodmoon import codedmask, simulation, count, decode, sky_variance\n",
-    "from bloodmoon import sky_significance\n",
+    "from bloodmoon import codedmask, simulation, count, decode, variance\n",
+    "from bloodmoon import snratio\n",
     "\n",
     "wfm = codedmask(\"wfm_mask.fits\")\n",
     "sdl = simulation(\"simdir/cam1a/cam1a_reconstructed.fits\")\n",
@@ -517,7 +517,7 @@
     "detector, _ = count(wfm, sdl.data)\n",
     "balanced = decode(wfm, detector)\n",
     "\n",
-    "snr = sky_significance(balanced, sky_variance(wfm, detector))"
+    "snr = snratio(balanced, variance(wfm, detector))"
    ]
   },
   {

--- a/tests/test_mask_camera.py
+++ b/tests/test_mask_camera.py
@@ -7,7 +7,7 @@ from bloodmoon.mask import codedmask
 from bloodmoon.mask import decode
 from bloodmoon.mask import encode
 from bloodmoon.mask import psf
-from bloodmoon.mask import sky_variance
+from bloodmoon.mask import variance
 
 
 class TestWFM(unittest.TestCase):
@@ -42,7 +42,7 @@ class TestWFM(unittest.TestCase):
     def test_decode_shape(self):
         detector = np.zeros(self.wfm.shape_detector)
         cc = decode(self.wfm, detector)
-        var = sky_variance(self.wfm, detector)
+        var = variance(self.wfm, detector)
         self.assertEqual(cc.shape, self.wfm.shape_sky)
         self.assertEqual(var.shape, self.wfm.shape_sky)
 

--- a/tests/test_mask_camera.py
+++ b/tests/test_mask_camera.py
@@ -7,7 +7,7 @@ from bloodmoon.mask import codedmask
 from bloodmoon.mask import decode
 from bloodmoon.mask import encode
 from bloodmoon.mask import psf
-from bloodmoon.mask import variance
+from bloodmoon.mask import sky_variance
 
 
 class TestWFM(unittest.TestCase):
@@ -42,7 +42,7 @@ class TestWFM(unittest.TestCase):
     def test_decode_shape(self):
         detector = np.zeros(self.wfm.shape_detector)
         cc = decode(self.wfm, detector)
-        var = variance(self.wfm, detector)
+        var = sky_variance(self.wfm, detector)
         self.assertEqual(cc.shape, self.wfm.shape_sky)
         self.assertEqual(var.shape, self.wfm.shape_sky)
 


### PR DESCRIPTION
Inserted new method to compute the balanced sky image variance from a coded-mask camera.

This new method is based on the computation of the array Lambda, which represent the expected Poisson counts on the detector image (thus, is less sensitive to Poisson fluctuations).
Let be:

-  R the system reconstruction array;
-  U the detector sensitivity array, or bulk;
- Lambda the array of the expected values of the detector counts.

The variance is then:
<img width="1663" height="202" alt="balskyvar" src="https://github.com/user-attachments/assets/de8ac8b4-d224-4050-90b5-14206d7119b1" />


Since we don't know the real content of Lambda, we can compute an approximation by taking into account the solid angle seen by each active pixel of the detector within the camera system (done in `utils.detector_solid_angle() `).

The solid angle is computed by considering only the camera geometry, taking into account the mask physical dimension, which represents the base of a pyramid whose vertex sits on the centre of each active element of the detector plane, and all the active elements coordinates (along the plane). The final array is masked with the detector bulk profile.