### PR TITLE
Inserted fractional 2D arrays shift

### DIFF
--- a/bloodmoon/images.py
+++ b/bloodmoon/images.py
@@ -400,44 +400,178 @@ def _interp(
 
 
 def _shift(
-    a: npt.NDArray,
-    shift_ext: tuple[int, int],
+    arr: npt.NDArray,
+    rows: int,
+    cols: int,
 ) -> npt.NDArray:
-    """Shifts a 2D numpy array by the specified amount in each dimension.
-    This exists because the scipy.ndimage one is slow.
+    """
+    Performs a 2D integer shift of an array using slicing.
+    Areas shifted in from outside the frame are filled with zeros.
 
     Args:
-        a: Input 2D numpy array to be shifted.
-        shift_ext: Tuple of (row_shift, column_shift) where positive values shift down/right
-            and negative values shift up/left. Values larger than array dimensions
-            result in an array of zeros.
+        arr (NDArray): Input 2D numpy array to be shifted.
+        rows (int): Shift value along vertical axis.
+        cols (int): Shift value along horizontal axis.
 
     Returns:
-        np.array: A new array of the same shape as the input, with elements shifted
-            and empty spaces filled with zeros.
+        output (NDArray): Shifted array with same shape.
+    
+    Raises:
+        ValueError: If shift values are not integer.
+    
+    ## Notes:
+        * Shift values larger than input array shape
+          results in an array full of zeros.
+        * This exists because is `~40` times quicker
+          than `scipy.ndimage.shift()`.
 
     Examples:
         >>> arr = np.array([[1, 2], [3, 4]])
-        >>> _shift(arr, (1, 0))  # Shift down by 1
+        >>> _shift(arr, 1, 0)   # Shift down by 1
         array([[0, 0],
                [1, 2]])
-        >>> _shift(arr, (0, -1))  # Shift left by 1
+        >>> _shift(arr, 0, -1)  # Shift left by 1
         array([[2, 0],
                [4, 0]])
     """
-    n, m = a.shape
-    shift_i, shift_j = shift_ext
-    if abs(shift_i) >= n or abs(shift_j) >= m:
-        # won't load into memory 66666666 x 66666666 bullshit matrix
-        return np.zeros_like(a)
-    vpadded = np.pad(a, ((0 if shift_i < 0 else shift_i, 0 if shift_i >= 0 else -shift_i), (0, 0)))
-    vpadded = vpadded[:n, :] if shift_i > 0 else vpadded[-n:, :]
-    hpadded = np.pad(
-        vpadded,
-        ((0, 0), (0 if shift_j < 0 else shift_j, 0 if shift_j >= 0 else -shift_j)),
+    if not (
+        isinstance(rows, int) and isinstance(cols, int)
+    ):
+        raise ValueError('Shift values must be integers.')
+    
+    # zero-shift
+    if rows == 0 and cols == 0:
+        return arr.copy()
+    
+    n, m = arr.shape
+    # avoid memory overload
+    if abs(rows) >= n or abs(cols) >= m:
+        return np.zeros_like(arr)
+    
+    arr_ = np.zeros_like(arr)
+    arr_ystart, arr_yend = max(0, -rows), n - max(0, rows)
+    arr_xstart, arr_xend = max(0, -cols), m - max(0, cols)
+
+    y_start, y_end = max(0, rows), n + min(0, rows)
+    x_start, x_end = max(0, cols), m + min(0, cols)
+
+    arr_[y_start : y_end, x_start : x_end] = (
+        arr[arr_ystart : arr_yend, arr_xstart : arr_xend]
     )
-    hpadded = hpadded[:, :m] if shift_j > 0 else hpadded[:, -m:]
-    return hpadded
+    return arr_
+
+
+def fshift(
+    arr: npt.NDArray,
+    shifty: int | float,
+    shiftx: int | float,
+) -> npt.NDArray:
+    """
+    Shifts a 2D array elements with integer or fractional shifts.
+    Areas shifted in from outside the frame are filled with zeros.
+
+    Args:
+        arr (NDArray):
+            Input 2D array.
+        shifty (int | float):
+            Shift along the rows axis.
+        shiftx (int | float):
+            Shift along the columns axis.
+
+    Returns:
+        output (NDArray): Shifted 2D array casted to float.
+    
+    ## Notes:
+        * Shift values larger than input array shape
+          results in an array full of zeros.
+        * This exists because is `~40` times quicker
+          than `scipy.ndimage.shift()`.
+        * CFR with url: [fshift](
+        https://github.com/yuri-evangelista/CodedMasks/blob/26a5bb2fa08e37c645f85d55a3a1ef038fe7497d/mask_utils/image_utils.py#L12
+        ).
+    
+    Examples:
+        >>> # INT shifts
+        >>> arr = np.ones((2, 2))
+        >>> fshift(arr, 1, 0)       # Shift down by 1
+        array([[0., 0.],
+               [1., 1.]])
+        
+        >>> fshift(arr, 0, -1)      # Shift left by 1
+        array([[1., 0.],
+               [1., 0.]])
+        
+        >>> # FLOAT shifts
+        >>> arr = np.array(
+        ...     [[0, 0, 0, 0, 0, 0, 0,],
+        ...      [0, 0, 0, 0, 0, 0, 0,],
+        ...      [0, 0, 1, 1, 1, 0, 0,],
+        ...      [0, 0, 1, 1, 1, 0, 0,],
+        ...      [0, 0, 0, 0, 0, 0, 0,],
+        ...      [0, 0, 0, 0, 0, 0, 0,]],
+        ... )
+
+        >>> fshift(arr, 1.1, 0)     # Shift up by 1.1
+        array(
+            [[0. , 0. , 0. , 0. , 0. , 0. , 0. ],
+             [0. , 0. , 0. , 0. , 0. , 0. , 0. ],
+             [0. , 0. , 0. , 0. , 0. , 0. , 0. ],
+             [0. , 0. , 0.9, 0.9, 0.9, 0. , 0. ],
+             [0. , 0. , 1. , 1. , 1. , 0. , 0. ],
+             [0. , 0. , 0.1, 0.1, 0.1, 0. , 0. ]],
+        )
+
+        >>> fshift(arr, 0, 1.1)     # Shift left by 1.1
+        array(
+            [[0. , 0. , 0. , 0. , 0. , 0. , 0. ],
+             [0. , 0. , 0. , 0. , 0. , 0. , 0. ],
+             [0. , 0. , 0. , 0.9, 1. , 1. , 0.1],
+             [0. , 0. , 0. , 0.9, 1. , 1. , 0.1],
+             [0. , 0. , 0. , 0. , 0. , 0. , 0. ],
+             [0. , 0. , 0. , 0. , 0. , 0. , 0. ]]
+        )
+    """
+    # zero-shift
+    if float(shifty) == 0.0 and float(shiftx) == 0.0:
+        return arr.copy()
+    
+    n, m = arr.shape
+    # avoid memory overload
+    if abs(shifty) >= n or abs(shiftx) >= m:
+        return np.zeros_like(arr)
+    
+    # compute int and decimal shifts
+    r, c = map(int, (shifty, shiftx))
+    rsign, csign = map(
+        lambda x: int(np.sign(x)),
+        (shifty, shiftx),
+    )
+    fr, fc = map(abs, (shifty - r, shiftx - c))
+
+    # - to perform the shifting and the decimal interpolation,
+    #   the array is divided into four weighted components
+    # - the first component is the INT shift, the other three
+    #   are the INT-shifted array in each direction, by one pixel
+    # - the weights are normalised to 1
+    shifted = _shift(arr, r, c)
+
+    # zero-fract shift
+    if fr == 0.0 and fc == 0.0:
+        return shifted
+    
+    shifted_01 = _shift(shifted, 0, csign)
+    shifted_10 = _shift(shifted, rsign, 0)
+    shifted_11 = _shift(shifted, rsign, csign)
+    
+    w00 = (1.0 - fr) * (1.0 - fc)
+    w01 = (1.0 - fr) * fc
+    w10 = fr * (1.0 - fc)
+    w11 = fr * fc
+
+    shifted_ = (
+        w00 * shifted + w01 * shifted_01 + w10 * shifted_10 + w11 * shifted_11
+    )
+    return shifted_
 
 
 def _erosion(

--- a/tests/test_shadowgrams.py
+++ b/tests/test_shadowgrams.py
@@ -1,8 +1,29 @@
 import unittest
 
 import numpy as np
+from numpy.typing import NDArray
+from scipy.ndimage import shift as ndshift
 
 from bloodmoon.images import _shift
+from bloodmoon.images import fshift
+
+
+def scipy_fshift(
+    arr: NDArray,
+    shifty: int | float,
+    shiftx: int | float,
+):
+    """
+    Applies fractional shift to input array.
+
+    The fractional shifting value is eroded from the end-points
+    wrt the shift verse and added to the front (for both rows/cols).
+    """
+    arr_ = ndshift(
+        arr, (shifty, shiftx), output='float', order=1,
+        mode='grid-constant', cval=0.0, prefilter=True,
+    )
+    return arr_
 
 
 class TestArrayShift(unittest.TestCase):
@@ -15,63 +36,140 @@ class TestArrayShift(unittest.TestCase):
     def test_basic_shifts(self):
         """Test basic positive shifts"""
         expected = np.array([[0, 0], [1, 2]])
-        np.testing.assert_array_equal(_shift(self.arr_2x2, (1, 0)), expected)
+        np.testing.assert_array_equal(_shift(self.arr_2x2, 1, 0), expected)
 
         expected = np.array([[0, 1], [0, 3]])
-        np.testing.assert_array_equal(_shift(self.arr_2x2, (0, 1)), expected)
+        np.testing.assert_array_equal(_shift(self.arr_2x2, 0, 1), expected)
 
     def test_negative_shifts(self):
         """Test negative shifts"""
         expected = np.array([[3, 4], [0, 0]])
-        np.testing.assert_array_equal(_shift(self.arr_2x2, (-1, 0)), expected)
+        np.testing.assert_array_equal(_shift(self.arr_2x2, -1, 0), expected)
 
         expected = np.array([[2, 0], [4, 0]])
-        np.testing.assert_array_equal(_shift(self.arr_2x2, (0, -1)), expected)
+        np.testing.assert_array_equal(_shift(self.arr_2x2, 0, -1), expected)
 
     def test_both_dimensions(self):
         """Test shifting in both dimensions simultaneously"""
         expected = np.array([[0, 0, 0], [0, 1, 2], [0, 4, 5]])
-        np.testing.assert_array_equal(_shift(self.arr_3x3, (1, 1)), expected)
+        np.testing.assert_array_equal(_shift(self.arr_3x3, 1, 1), expected)
 
         expected = np.array([[5, 6, 0], [8, 9, 0], [0, 0, 0]])
-        np.testing.assert_array_equal(_shift(self.arr_3x3, (-1, -1)), expected)
+        np.testing.assert_array_equal(_shift(self.arr_3x3, -1, -1), expected)
 
     def test_large_shifts(self):
         """Test shifts larger than array dimensions"""
         expected = np.zeros((2, 2))
-        np.testing.assert_array_equal(_shift(self.arr_2x2, (20, 0)), expected)
-        np.testing.assert_array_equal(_shift(self.arr_2x2, (0, 20)), expected)
-        np.testing.assert_array_equal(_shift(self.arr_2x2, (-20, 0)), expected)
-        np.testing.assert_array_equal(_shift(self.arr_2x2, (0, -20)), expected)
+        np.testing.assert_array_equal(_shift(self.arr_2x2, 20, 0), expected)
+        np.testing.assert_array_equal(_shift(self.arr_2x2, 0, 20), expected)
+        np.testing.assert_array_equal(_shift(self.arr_2x2, -20, 0), expected)
+        np.testing.assert_array_equal(_shift(self.arr_2x2, 0, -20), expected)
 
     def test_zero_shift(self):
         """Test zero shift returns original array"""
-        np.testing.assert_array_equal(_shift(self.arr_2x2, (0, 0)), self.arr_2x2)
+        np.testing.assert_array_equal(_shift(self.arr_2x2, 0, 0), self.arr_2x2)
 
     def test_different_shapes(self):
         """Test with non-square arrays"""
         expected = np.array([[0, 1, 2], [0, 4, 5]])
-        np.testing.assert_array_equal(_shift(self.arr_2x3, (0, 1)), expected)
+        np.testing.assert_array_equal(_shift(self.arr_2x3, 0, 1), expected)
 
     def test_edge_cases(self):
         """Test edge cases like empty and single-element arrays"""
         # Empty array
         empty_arr = np.array([[]])
-        np.testing.assert_array_equal(_shift(empty_arr, (1, 1)), empty_arr)
+        np.testing.assert_array_equal(_shift(empty_arr, 1, 1), empty_arr)
 
         # Single element array
         single_arr = np.array([[1]])
         expected = np.array([[0]])
-        np.testing.assert_array_equal(_shift(single_arr, (1, 0)), expected)
+        np.testing.assert_array_equal(_shift(single_arr, 1, 0), expected)
 
     def test_different_dtypes(self):
         """Test with different data types"""
         # Float array
         float_arr = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=float)
         expected = np.array([[0.0, 0.0], [1.0, 2.0]])
-        np.testing.assert_array_equal(_shift(float_arr, (1, 0)), expected)
+        np.testing.assert_array_equal(_shift(float_arr, 1, 0), expected)
 
         # Boolean array
         bool_arr = np.array([[True, False], [False, True]], dtype=bool)
         expected = np.array([[True, False], [False, False]])
-        np.testing.assert_array_equal(_shift(bool_arr, (-1, -1)), expected)
+        np.testing.assert_array_equal(_shift(bool_arr, -1, -1), expected)
+    
+    def test_equal2scipyfshift(self):
+        """
+        Test if `fshift()` has the same output of scipy's `shift()`,
+        with shifts greater than 1.
+        """
+        arr = np.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0,],
+                [0, 0, 0, 0, 0, 0, 0,],
+                [0, 0, 1, 1, 1, 0, 0,],
+                [0, 0, 1, 1, 1, 0, 0,],
+                [0, 0, 0, 0, 0, 0, 0,],
+                [0, 0, 0, 0, 0, 0, 0,],
+            ],
+        )
+
+        shifty, shiftx = 2.1, 3.4
+        expected = scipy_fshift(arr, shifty, shiftx)
+        shifted = fshift(arr, shifty, shiftx)
+        np.testing.assert_array_almost_equal(expected, shifted)
+
+        shifty, shiftx = -2.1, 3.4
+        expected = scipy_fshift(arr, shifty, shiftx)
+        shifted = fshift(arr, shifty, shiftx)
+        np.testing.assert_array_almost_equal(expected, shifted)
+
+        shifty, shiftx = 2.1, -3.4
+        expected = scipy_fshift(arr, shifty, shiftx)
+        shifted = fshift(arr, shifty, shiftx)
+        np.testing.assert_array_almost_equal(expected, shifted)
+
+        shifty, shiftx = -2.1, -3.4
+        expected = scipy_fshift(arr, shifty, shiftx)
+        shifted = fshift(arr, shifty, shiftx)
+        np.testing.assert_array_almost_equal(expected, shifted)
+
+    def test_equal2scipyfshift_decimal(self):
+        """
+        Test if `fshift()` has the same output of scipy's `shift()`,
+        with shifts in (0, 1).
+        """
+        arr = np.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0,],
+                [0, 0, 0, 0, 0, 0, 0,],
+                [0, 0, 1, 1, 1, 0, 0,],
+                [0, 0, 1, 1, 1, 0, 0,],
+                [0, 0, 0, 0, 0, 0, 0,],
+                [0, 0, 0, 0, 0, 0, 0,],
+            ],
+        )
+
+        shifty, shiftx = 0.1, 0.4
+        expected = scipy_fshift(arr, shifty, shiftx)
+        shifted = fshift(arr, shifty, shiftx)
+        np.testing.assert_array_almost_equal(expected, shifted)
+
+        shifty, shiftx = -0.1, 0.4
+        expected = scipy_fshift(arr, shifty, shiftx)
+        shifted = fshift(arr, shifty, shiftx)
+        np.testing.assert_array_almost_equal(expected, shifted)
+
+        shifty, shiftx = 0.1, -0.4
+        expected = scipy_fshift(arr, shifty, shiftx)
+        shifted = fshift(arr, shifty, shiftx)
+        np.testing.assert_array_almost_equal(expected, shifted)
+
+        shifty, shiftx = -0.1, -0.4
+        expected = scipy_fshift(arr, shifty, shiftx)
+        shifted = fshift(arr, shifty, shiftx)
+        np.testing.assert_array_almost_equal(expected, shifted)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
First mini-PR for sources modelling update.

In this PR:
**1. Changed `_shift()` logic**
Now it exploits array slicing and array view to optimise the "shifting" operation (`numpy` is optimised wrt these two operations).
This version is faster wrt old version for big arrays.

**2. Inserted `fshift()`**
This version mimic scipy's `shift()` method, while being ~40 times faster (see tests for more info and for specific `scipy.ndimage.shift()` implementation).

**3. Array shift tests update**
The tests for  `_shift()` have been updated, and tests for `fshift()` have been added.