### PR TITLE
Modified Erosion and Vignetting

### DIFF
--- a/bloodmoon/images.py
+++ b/bloodmoon/images.py
@@ -583,8 +583,6 @@ def _erosion(
     2D matrix erosion for simulating finite thickness effect in shadow projections.
     It takes a mask array and "thins" the mask elements across the columns' direction.
 
-    Comes with NO safeguards: setting cuts larger than step may remove slits or make them negative.
-
     ⢯⣽⣿⣿⣿⠛⠉⠀⠀⠉⠉⢛⢟⡻⣟⡿⣿⢿⣿⣿⢿⣻⣟⡿⣟⡿⣿⣻⣟⣿⣟⣿⣻⣟⡿⣽⣻⠿⣽⣻⢟⡿⣽⢫⢯⡝
     ⢯⣞⣷⣻⠤⢀⠀⠀⠀⠀⠀⠀⠀⠑⠌⢳⡙⣮⢳⣭⣛⢧⢯⡽⣏⣿⣳⢟⣾⣳⣟⣾⣳⢯⣽⣳⢯⣟⣷⣫⢿⣝⢾⣫⠗⡜
     ⡿⣞⡷⣯⢏⡴⢀⠀⠀⣀⣤⠤⠀⠀⠀⠀⠑⠈⠇⠲⡍⠞⡣⢝⡎⣷⠹⣞⢧⡟⣮⢷⣫⢟⡾⣭⢷⡻⢶⣏⣿⢺⣏⢮⡝⢌
@@ -621,22 +619,29 @@ def _erosion(
     Notes:
         * See tests for usage examples.
     """
-    if not np.issubdtype(arr.dtype, np.integer):
-        raise ValueError(
-            "Input array must be of integer type. "
-            "Hint: make sure that 1. your mask dtype is integer, and 2. it only contains ones and zeros."
-        )
-
+    # check if there's erosion
+    if not cut:
+        return arr
+    
     # number of bins to cut
     ncuts = int(cut / step)
-    cutted = arr * (arr & _shift(arr, (0, ncuts))) if ncuts else arr
+    arr_mask = (arr > 0) & (_shift(arr, 0, ncuts) > 0)
+    cutted = arr * arr_mask if ncuts else arr
 
     # array indexes to be fractionally reduced:
-    #   - the bin with the decimal values is the one
-    #     to the left or right wrt the cutted bins
+    # - the bin with the decimal values is the one
+    #   to the left or right wrt the cutted bins
+    # - since `arr` may have values in [0, 1], we
+    #   look at the element greater than zero to
+    #   perform the mask elements erosion
+    # - to NOT risk having negative values, the
+    #   erosion value is not subtracted directly
     erosion_value = abs(cut / step - ncuts)
-    border = (cutted - _shift(cutted, (0, int(np.sign(cut))))) > 0
-    return cutted - border * erosion_value
+    cutted_mask = (
+        np.array((cutted > 0), dtype=int) - np.array((_shift(cutted, 0, int(np.sign(cut))) > 0), dtype=int)
+    )
+    border = (cutted_mask > 0)
+    return cutted * (1.0 - border * erosion_value)
 
 
 def _unframe(a: npt.NDArray, value: float = 0.0) -> npt.NDArray:

--- a/bloodmoon/optim.py
+++ b/bloodmoon/optim.py
@@ -119,8 +119,8 @@ def apply_vignetting(
 
               \       \  \
     ___________\       \  \____________
-                \       \  x            MASK ELEMENT
-    ___________  \       \ _x___________
+               |\       \ |x            MASK ELEMENT
+    ___________| \       \|_x___________
                   \       \  x
                    \       \  x
                     \       \  x
@@ -144,22 +144,43 @@ def apply_vignetting(
         - The mask thickness parameter from the camera model determines the strength
           of the effect
     """
+    def project_mask_thickness(shift: float, bin_dim: float) -> float:
+        """
+        Projects the mask thickness on the mask binning elements, and
+        corrects the projection value to allows for correct erosion
+        of the mask physical elements starting from the pixels' edges.
+        """
+        # since the mask detector distance is defined as the distance between the
+        # detector top and the mask top, erosion shall cut on the left-side of the
+        # shadowgram when sources have negative `angle`.
+        # if the mask detector distance was defined as the distance between the
+        # detector top and the mask bottom, erosion should have been applied to the
+        # right side, i.e. `proj` should be multiplied by -1.
+        angle = np.arctan(shift / camera.specs.mask_detector_distance)
+        proj = camera.specs.mask_thickness * np.tan(angle)
+        shift_px = shift / bin_dim
+        # the mask thickness projection has to be corrected by considering the
+        # erosion pixel start point, due to the discretisation of the projection
+        # https://github.com/yuri-evangelista/CodedMasks/blob/main/mask_050_1040x17/new_erosion_20251024.ipynb
+        bin_erosion_start = (1.0 - abs(shift_px - int(shift_px))) * bin_dim
+        return proj + np.sign(proj) * bin_erosion_start
+    
     bins = camera.bins_detector
+    bin_dim_x, bin_dim_y = (
+        bins.x[1] - bins.x[0],
+        bins.y[1] - bins.y[0],
+    )
 
-    angle_x_rad = np.arctan(shift_x / camera.specs.mask_detector_distance)
-    red_factor = camera.specs.mask_thickness * np.tan(angle_x_rad)
-    # since the mask detector distance is defined as the distance between the
-    # detector top and the mask top, erosion shall cut on the left-side of the
-    # shadowgram when sources have negative `angle_x_rad`.
-    # if the mask detector distance was defined as the distance between the
-    # detector top and the mask bottom, erosion should have been applied to the
-    # right side, i.e. `red_factor` should be multiplied by -1.
-    sg1 = _erosion(shadowgram, bins.x[1] - bins.x[0], red_factor)
+    red_factor_x = project_mask_thickness(shift_x, bin_dim_x)
+    sg_x = _erosion(shadowgram, bin_dim_x, red_factor_x)
 
-    angle_y_rad = np.arctan(shift_y / camera.specs.mask_detector_distance)
-    red_factor = camera.specs.mask_thickness * np.tan(angle_y_rad)
-    sg2 = _erosion(shadowgram.T, bins.y[1] - bins.y[0], red_factor)
-    return sg1 * sg2.T
+    # - we apply the y-axis erosion to `sg_x`, otherwise the decimal
+    #   values of the input shifted shadowgram would be squared
+    # - the erosion on the two axes is still independent, as it must be
+    red_factor_y = project_mask_thickness(shift_y, bin_dim_y)
+    sg_y = _erosion(sg_x.T, bin_dim_y, red_factor_y)
+
+    return sg_y.T
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## **Erosion**
- function logic is the same
- edit erosion mechanisms to make it robust against fractional mask array shifts
- tests are the same and working

## **Vignetting**
- inserted mask thickness proj correction (CFR with [Yuri](https://github.com/yuri-evangelista/CodedMasks/blob/main/mask_050_1040x17/new_erosion_20251024.ipynb))
- fixed erosion application to rows and cols axes to make it robust against fractional mask array shifts

-------------------------------------------------------------------------------------------------------
NOTE: the "Merge branch 'peppedilillo:newSG' into newSG" commit is redundant (my bad :'c )